### PR TITLE
Feat-27/Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release CI
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          
+      - name: Determine version bump
+        id: bump
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          if [[ $BRANCH_NAME == Feat-* ]]; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+          elif [[ $BRANCH_NAME == Enhancement-* ]]; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+          elif [[ $BRANCH_NAME == Fix-* ]] || [[ $BRANCH_NAME == bug/* ]]; then
+            echo "bump=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install -g semantic-release @semantic-release/git @semantic-release/github
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_LEVEL: ${{ steps.bump.outputs.bump }}
+        run: |
+          if [ ! -z "$BUMP_LEVEL" ]; then
+            npx semantic-release --preset angular --release-rules '[{"type":"*","release":"${{ steps.bump.outputs.bump }}"}]'
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,9 @@ jobs:
           
       - name: Determine version bump
         id: bump
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           if [[ $BRANCH_NAME == Feat-* ]]; then
             echo "bump=major" >> $GITHUB_OUTPUT
           elif [[ $BRANCH_NAME == Enhancement-* ]]; then


### PR DESCRIPTION
Se ha creado un workflow que permite versionar todas las PRs que se hagan a main. La rama de donde venga tiene que seguir el siguiente patron para que detecte bien el cambio y haga automáticamente la release en GitHub:

- Feat-*
- Enhancement-*
- Fix-*

Actualmente no es posible probar si funciona el workflow, ya que necesita que se haga una PR a main y habría que mirar si crea correctamente la version. Lo único que se podría comprobar es si la sintaxis esta bien escrita y que las políticas estén bien reflejadas en el código. En caso que falle el workflow, seria conveniente mantener esta rama o directamente ir haciendo commits a main hasta que veamos que funcione correctamente, habría que revisar como realizar las pruebas.