### PR TITLE
Feat 23/filtros avanzados

### DIFF
--- a/app/modules/dataset/models.py
+++ b/app/modules/dataset/models.py
@@ -1,10 +1,13 @@
 from datetime import datetime
 from enum import Enum
 
-from flask import request
-from sqlalchemy import Enum as SQLAlchemyEnum
+from flask import request  # type: ignore
+from sqlalchemy import Enum as SQLAlchemyEnum  # type: ignore
+from flamapy.core.discover import DiscoverMetamodels  # type: ignore
 
 from app import db
+
+dm = DiscoverMetamodels()
 
 
 class PublicationType(Enum):
@@ -83,6 +86,24 @@ class DataSet(db.Model):
 
     def files(self):
         return [file for fm in self.feature_models for file in fm.files]
+
+    def highest_number_of_configurations(self) -> int:
+        res = 0
+        files = [file for fm in self.feature_models for file in fm.files]
+        for f in files:
+            result = dm.use_operation_from_file("PySATConfigurationsNumber", f.get_path())
+            if result > res:
+                res = result
+        return res
+
+    def number_of_core_features(self) -> int:
+        res = 0
+        files = [file for fm in self.feature_models for file in fm.files]
+        for f in files:
+            result = dm.use_operation_from_file("PySATCoreFeatures", f.get_path())
+            if len(result) > res:
+                res = len(result)
+        return res
 
     def delete(self):
         db.session.delete(self)

--- a/app/modules/explore/assets/scripts.js
+++ b/app/modules/explore/assets/scripts.js
@@ -39,6 +39,8 @@ function send_query() {
                 query: document.querySelector('#query').value,
                 publication_type: document.querySelector('#publication_type').value,
                 sorting: document.querySelector('[name="sorting"]:checked').value,
+                config_number: document.querySelector('#config_number').value,
+                core_features: document.querySelector('#core_features').value
             };
 
             console.log(document.querySelector('#publication_type').value);
@@ -57,7 +59,7 @@ function send_query() {
                     document.getElementById('results').innerHTML = '';
 
                     populateTagsSelect(data);
-
+                    
                     // size limit
                     const sizeLimit = parseInt(document.querySelector('#size_limit').value) * 1024 * 1024;
                     let filteredData = data.filter(dataset => dataset.total_size_in_bytes <= sizeLimit);

--- a/app/modules/explore/routes.py
+++ b/app/modules/explore/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, jsonify
+from flask import render_template, request, jsonify  # type: ignore
 
 from app.modules.explore import explore_bp
 from app.modules.explore.forms import ExploreForm

--- a/app/modules/explore/services.py
+++ b/app/modules/explore/services.py
@@ -6,5 +6,12 @@ class ExploreService(BaseService):
     def __init__(self):
         super().__init__(ExploreRepository())
 
-    def filter(self, query="", sorting="newest", publication_type="any", tags=[], **kwargs):
-        return self.repository.filter(query, sorting, publication_type, tags, **kwargs)
+    def filter(self, query="", sorting="newest", publication_type="any", tags=[],
+               config_number=0, core_features=0, **kwargs):
+
+        if config_number == '' or int(config_number) < 0:
+            config_number = 0
+        if core_features == '' or int(core_features) < 0:
+            core_features = 0
+
+        return self.repository.filter(query, sorting, publication_type, tags, config_number, core_features, **kwargs)

--- a/app/modules/explore/templates/explore/index.html
+++ b/app/modules/explore/templates/explore/index.html
@@ -102,6 +102,20 @@
 
                     <div class="col-lg-6">
                         <div class="mb-3">
+                            <label class="form-label" for="config_number">Number of configurations</label>
+                            <input type="number" class="form-control" id="config_number" name="config_number" min="0" value="0">
+                        </div>
+                    </div>
+
+                    <div class="col-lg-6">
+                        <div class="mb-3">
+                            <label class="form-label" for="core_features">Number of features</label>
+                            <input type="number" class="form-control" id="core_features" name="core_features" min="0" value="0">
+                        </div>
+                    </div>
+
+                    <div class="col-lg-6">
+                        <div class="mb-3">
                             <label class="form-label" for="size_limit">Size limit: <span
                                     id="size_limit_value">10.000</span> MB</label>
                             <input type="range" class="form-range" id="size_limit" min="0" max="10000" value="10000"


### PR DESCRIPTION
Se ha realizado la funcionalidad con dos filtros adicionales:
- El filtro correspondiente a number of features, filtra aquellos datasets que contienen al menos un modelo con el mínimo de "core features" indicado
- El filtro correspondiente a number of products filtra aquellos datasets que contienen al menos un modelo con el mínimo de "number of configurations" indicado

La terminología se puede consultar [aquí](https://docs.flamapy.org/framework/operations), todo se ha contrastado con la documentación de flamapy dado que al ser los datos a tratar modelos de UVL era necesario consultarla anteriormente a desarrolla esta feature