### PR TITLE
Fix-39/Arreglar el workflow de las releases UPDATED

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.head_commit.message startsWith('Merge')
+    if: ${{ ! startsWith(github.event.head_commit.message, 'Merge') }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Parece que ha habido un problema con la sintaxis de la condición que se encuentra en la action, el cual ya ha sido resuelto.

Si después de solucionar este problema sigue sin funcionar, se procederá a revertir los cambios y eliminar el workflow.