### PR TITLE
Fix-39/Arreglar el workflow de las releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ ! startsWith(github.event.head_commit.message, 'Merge') }}
+    if: ${{ startsWith(github.event.head_commit.message, 'Merge') }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Se ha determinado que la condición de ejecución del "job" estaba mal escrita, ahora definitivamente debe ejecutar el workflow. En caso de no funcionar, se elimina la action 100%.